### PR TITLE
Add some comments explaining the relationship between IMAccount.loginStatus and .loginStatusMessage

### DIFF
--- a/Sources/IMCore/include/IMAccount.h
+++ b/Sources/IMCore/include/IMAccount.h
@@ -16,6 +16,14 @@
 +(NSPredicate*)predicateForContactsMatchingHandleStrings:(NSArray*)strings;
 @end
 
+/**
+ IMAccount.loginStatus corresponds to IMAccount.loginStatusMessage, where
+ .loggedOut == "Offline",
+ .disconnected == "Disconnected",
+ .disconnecting == "Disconnecting",
+ .loggingIn == "Connecting",
+ .loggedIn == "Connected"
+ */
 typedef NS_ENUM(NSUInteger, IMAccountLoginStatus) {
     IMAccountStatusLoggedOut,
     IMAccountStatusDisconnected,


### PR DESCRIPTION
Fairly straightforward - this was just a relationship I noticed while working on something else, and thought it would be useful for other people using these headers. Not quite certain if these sorts of comments are desired in these headers, though, so let me know if this is okay.