### PR TITLE
Update a lot of methods and classes to reflect usage of tapbacks in Ventura

### DIFF
--- a/Sources/IMCore/include/IMChat.h
+++ b/Sources/IMCore/include/IMChat.h
@@ -101,7 +101,7 @@ typedef NS_ENUM(NSInteger, IMChatJoinState) {
 + (void)removeGUIDInAttemptingListInScrutinyMode:(id)arg1;
 + (BOOL)isGUIDInAttemptingListInScrutinyMode:(id)arg1;
 + (void)storeGUIDInAttemptingListInScrutinyMode:(id)arg1;
-+ (id)__im_adjustMessageSummaryInfoForSending:(id)arg1;
++ (NSDictionary *)__im_adjustMessageSummaryInfoForSending:(NSDictionary *)arg1 API_DEPRECATED("Use -[IMTapback adjustMessageSummaryInfoForSending:] instead", macos(10.0, 12.5), ios(10.0, 15.2));
 @property(retain, nonatomic) NSString *lastAddressedSIMID; // @synthesize lastAddressedSIMID=_lastAddressedSIMID;
 @property(retain, nonatomic) NSString *currentLocationGUID; // @synthesize currentLocationGUID=_currentLocationGUID;
 @property(retain, nonatomic) IMOrderingTools *orderingTools; // @synthesize orderingTools=_orderingTools;

--- a/Sources/IMCore/include/IMMessage.h
+++ b/Sources/IMCore/include/IMMessage.h
@@ -76,7 +76,7 @@ typedef NS_ENUM(NSInteger, IMMessageDescriptionType) {
 + (id)breadcrumbMessageWithText:(id)arg1 associatedMessageGUID:(id)arg2 balloonBundleID:(id)arg3 fileTransferGUIDs:(id)arg4 payloadData:(id)arg5 threadIdentifier:(id)arg6 API_AVAILABLE(macos(10.16), ios(14.0), watchos(7.0));
 + (id)editedMessageWithOriginalMessage:(id)arg1 originalPrefixedGUID:(id)arg2 newBody:(id)arg3;
 + (IMMessage*)instantMessageWithAssociatedMessageContent:(id)arg1 flags:(unsigned long long)arg2 associatedMessageGUID:(id)arg3 associatedMessageType:(long long)arg4 associatedMessageRange:(struct _NSRange)arg5 messageSummaryInfo:(id)arg6 ;
-+ (IMMessage*)instantMessageWithAssociatedMessageContent:(id)arg1 flags:(unsigned long long)arg2 associatedMessageGUID:(id)arg3 associatedMessageType:(long long)arg4 associatedMessageRange:(struct _NSRange)arg5 messageSummaryInfo:(id)arg6 threadIdentifier:(id)arg7 API_AVAILABLE(macos(10.16), ios(14.0), watchos(7.0));
++ (IMMessage*)instantMessageWithAssociatedMessageContent:(NSAttributedString *)arg1 flags:(unsigned long long)arg2 associatedMessageGUID:(NSString *)arg3 associatedMessageType:(long long)arg4 associatedMessageRange:(struct _NSRange)arg5 messageSummaryInfo:(NSDictionary *)arg6 threadIdentifier:(NSString *)arg7 API_AVAILABLE(macos(10.16), ios(14.0), watchos(7.0));
 @property(nonatomic) unsigned long long sortID; // @synthesize sortID=_sortID;
 @property(nonatomic) BOOL isSOS; // @synthesize isSOS=_isSOS;
 @property(retain, nonatomic) NSString *notificationIDSTokenURI; // @synthesize notificationIDSTokenURI=_notificationIDSTokenURI;

--- a/Sources/IMSharedUtilities/include/IMSharedUtilities.h
+++ b/Sources/IMSharedUtilities/include/IMSharedUtilities.h
@@ -134,6 +134,7 @@
 #import "IMSuperToPlainParserContext.h"
 #import "IMSuperToSuperSanitizerContext.h"
 #import "IMTapback.h"
+#import "IMTapbackSender.h"
 #import "IMTUConversationItem.h"
 #import "IMToSuperParserContext.h"
 #import "IMToSuperParserFrame.h"

--- a/Sources/IMSharedUtilities/include/IMTapback.h
+++ b/Sources/IMSharedUtilities/include/IMTapback.h
@@ -13,7 +13,9 @@
 NS_CLASS_AVAILABLE(13_0, 16_0)
 @interface IMTapback: NSObject
 @property(readonly, nonatomic) long long associatedMessageType;
++ (IMTapback *)tapbackWithAssociatedMessageType:(long long)associatedMessageType messageSummaryInfo:(NSDictionary *)messageSummaryInfo;
 - (NSString *)previewStringWithMessageSummaryInfo:(NSDictionary *)arg2 senderDisplayName:(NSString *)arg3 isFromMe:(BOOL)arg4;
+- (NSDictionary *)adjustMessageSummaryInfoForSending:(NSDictionary *)summaryInfo;
 
 @end
 

--- a/Sources/IMSharedUtilities/include/IMTapbackSender.h
+++ b/Sources/IMSharedUtilities/include/IMTapbackSender.h
@@ -1,0 +1,27 @@
+//
+//  IMTapbackSender.h
+//  
+//
+//  Created by June on 12/13/22.
+//
+
+#ifndef IMTapbackSender_h
+#define IMTapbackSender_h
+
+#import <Foundation/Foundation.h>
+
+@class IMTapback, IMChat, IMMessagePartChatItem;
+
+NS_CLASS_AVAILABLE(13_0, 16_0)
+@interface IMTapbackSender: NSObject
+- (instancetype)initWithTapback:(IMTapback *)tapback chat:(IMChat *)chat messagePartChatItem:(IMMessagePartChatItem *)messagePartChatItem;
+- (NSString *)backwardCompatibilityString;
+- (NSAttributedString *)attributedContentString;
+- (NSString *)messageGUID;
+- (NSRange)messagePartRange;
+- (NSDictionary *)messageSummaryInfo;
+- (NSString *)threadIdentifier;
+- (void)send;
+@end
+
+#endif /* IMTapbackSender_h */


### PR DESCRIPTION
Ventura tapback support is not functional in Barcelona right now, so I've fixed that (and you should expect a PR there soon) and these methods are needed to make the changes in Barcelona compile. I've also added some more explicit type annotations that would've helped me while working on it.