### PR TITLE
Add comment specifying types of retargetTransfer arguments

### DIFF
--- a/Sources/IMCore/include/IMCore.h
+++ b/Sources/IMCore/include/IMCore.h
@@ -186,6 +186,7 @@ BOOL IMSPIQueryIMMessageItemsWithGUIDsAndQOS(NSArray<NSString *> *__strong, disp
 BOOL IMSPIQueryMessagesWithGUIDsAndQOS(NSArray<NSString *> *__strong, dispatch_qos_class_t, __strong dispatch_queue_t, __strong void (^)(NSArray*));
 NSObject* IMCopyDDScannerResultFromAttributedStringData(NSData*);
 BOOL IMCoreSimulatedEnvironmentEnabled();
+void _IMIntentsApiInit() API_AVAILABLE(macos(13.0));
 
 extern NSString* ABIMHandlesChangedNotification;
 extern NSString* IMAVChatInfoNotification;

--- a/Sources/IMCore/include/IMFileTransferCenter.h
+++ b/Sources/IMCore/include/IMFileTransferCenter.h
@@ -52,7 +52,8 @@
 @property(readonly, nonatomic) __weak NSArray *activeTransfers;
 @property(readonly, nonatomic) NSDictionary<NSString*, IMFileTransfer*> *transfers;
 - (id)transfersForAccount:(id)arg1;
-- (void)retargetTransfer:(id)arg1 toPath:(id)arg2;
+// NOTICE: for retargetTransfer:, arg1 is an IMFileTransfer in < macOS 13.0, and it is an NSString in >= macOS 13.0 (the guid of the transfer)
+- (void)retargetTransfer:(id)arg1 toPath:(NSString *)path;
 - (void)deleteTransfer:(id)arg1;
 - (void)removeTransfer:(id)arg1;
 - (void)stopTransfer:(id)arg1;


### PR DESCRIPTION
On Ventura, passing in an `IMFileTransfer*` as the first argument to `retargetTransfer:` will cause a crash, since it'll try to send it to some other process over XPC, but it can't be `NSSecureCoding`'d, and they're expecting a GUID instead (referring to which  transfer you're trying to retarget). We can't create a new method, since clang will complain about two identical method signatures, and we could theoretically weak-link to fix this issue (and thus get stronger typing than we currently have), but I thought that would be cumbersome and take a second to get right, so I figured this comment would do now.

Additionally, I'll be filing a PR with Barcelona soon to fix images crashing on Ventura.