### PR TITLE
Add methods to rich link-related objects

### DIFF
--- a/Sources/IMCore/include/IMBalloonPluginDataSource.h
+++ b/Sources/IMCore/include/IMBalloonPluginDataSource.h
@@ -6,7 +6,7 @@
 
 #import <objc/NSObject.h>
 
-@class DDScannerResult, IMChat, IMMessage, IMPluginPayload, LPLinkMetadata, NSArray, NSAttributedString, NSData, NSMutableSet, NSString, NSURL;
+@class DDScannerResult, IMChat, IMMessage, IMPluginPayload, LPLinkMetadata, LPMessagesPayload, NSArray, NSAttributedString, NSData, NSMutableSet, NSString, NSURL;
 
 @interface IMBalloonPluginDataSource : NSObject
 {
@@ -110,6 +110,13 @@
 @property(readonly, nonatomic) NSArray *allPayloads;
 - (id)initWithPluginPayload:(id)arg1;
 - (id)initWithMessageGUID:(id)arg1 payload:(id)arg2 dataDetectedResult:(id)arg3 url:(id)arg4;
+- (void)dispatchMetadataUpdateToAllClients API_AVAILABLE(macos(13.0), ios(16.0));
+- (void)dispatchDidReceiveMetadataToAllClients API_DEPRECATED("Use dispatchMetadataUpdateToAllClients on ventura and later", macos(10.0, 12.5), ios(5.0, 15.2));
+- (void)_didFetchMetadata:(LPLinkMetadata *)metadata error:(NSError **)error NS_SWIFT_NAME(_didFetchMetadata(_:error:));
+- (void)updateRichLinkWithFetchedMetadata:(LPLinkMetadata * _Nonnull)metadata NS_SWIFT_NAME(updateRichLink(with:));
+- (void)_startFetchingMetadata;
+- (void)createEmptyMetadataWithOriginalURL;
+@property(nonatomic, nonnull) LPMessagesPayload *richLink;
 
 @end
 

--- a/Sources/IMCore/include/IMMessage.h
+++ b/Sources/IMCore/include/IMMessage.h
@@ -85,7 +85,7 @@ typedef NS_ENUM(NSInteger, IMMessageDescriptionType) {
 @property(retain, nonatomic) NSString *expressiveSendStyleID; // @synthesize expressiveSendStyleID=_expressiveSendStyleID;
 @property(retain, nonatomic) NSString *sourceApplicationID; // @synthesize sourceApplicationID=_sourceApplicationID;
 @property(retain, nonatomic) NSString *associatedBalloonBundleID; // @synthesize associatedBalloonBundleID=_associatedBalloonBundleID;
-@property(retain, nonatomic) NSData *payloadData; // @synthesize payloadData=_payloadData;
+@property(retain, nonatomic, nullable) NSData *payloadData; // @synthesize payloadData=_payloadData;
 @property(retain, nonatomic) NSString *balloonBundleID; // @synthesize balloonBundleID=_balloonBundleID;
 @property(retain, nonatomic, setter=_updateLocale:) NSString *locale; // @synthesize locale=_locale;
 @property(retain, nonatomic, setter=_updateBizIntent:) NSDictionary *bizIntent; // @synthesize bizIntent=_bizIntent;

--- a/Sources/LinkPresentationPrivate/include/LinkPresentationPrivate.h
+++ b/Sources/LinkPresentationPrivate/include/LinkPresentationPrivate.h
@@ -17,6 +17,7 @@
 @class LPImage;
 @class LPVideo;
 @class LPAudio;
+@class LPMessagesPayload;
 
 @interface LPLinkMetadata (Private)
 @property (nonatomic, copy, nullable) NSURL *URL;
@@ -122,6 +123,15 @@
 - (instancetype)initWithData:(NSData *)data MIMEType:(NSString *)MIMEType;
 - (instancetype)initByReferencingFileURL:(NSURL *)fileURL MIMEType:(NSString *)MIMEType properties:(LPAudioProperties *)properties;
 - (instancetype)initWithData:(NSData *)data MIMEType:(NSString *)MIMEType properties:(LPAudioProperties *)properties;
+@end
+
+API_AVAILABLE(macos(10.15))
+@interface LPMessagesPayload: NSObject
+@property (nonatomic, nonnull) LPLinkMetadata *metadata;
+@property (nonatomic, getter=isPlaceholder, setter=setPlaceholder:) BOOL placeholder;
+@property (nonatomic) BOOL needsCompleteFetch;
+@property (nonatomic) BOOL needsSubresourceFetch;
+- (NSData * _Nonnull)dataRepresentationWithOutOfLineAttachments:(NSArray * _Nullable * _Nullable)attachments;
 @end
 
 


### PR DESCRIPTION
This adds more methods on rich-link related objects (such as `IMBalloonPluginDataSource`) to enable calling their methods directly, instead of treating them as implementing certain protocols, and calling their methods through that. I'll be posting a similar PR to barcelona soon.

This also explicitly marks the nullability of a property that I've seen to be nil.