### PR TITLE
Update imchat retrieval methods with nullability and types for ventura

### DIFF
--- a/Sources/IMCore/include/IMChat.h
+++ b/Sources/IMCore/include/IMChat.h
@@ -122,7 +122,7 @@ typedef NS_ENUM(NSInteger, IMChatJoinState) {
 @property(nonatomic) void *contextInfo; // @synthesize contextInfo=_context;
 @property(readonly, nonatomic) IMChatStyle chatStyle; // @synthesize chatStyle=_style;
 @property(readonly, nonatomic) NSArray<IMHandle*> *participants; // @synthesize participants=_participants;
-@property(readonly, nonatomic) IMAccount *account; // @synthesize account=_account;
+@property(readonly, nonatomic, nonnull) IMAccount *account; // @synthesize account=_account;
 @property(readonly, nonatomic) NSString *guid; // @synthesize guid=_guid;
 @property(retain, nonatomic, setter=_setGUIDs:) NSMutableSet *_guids; // @synthesize _guids;
 @property(retain, nonatomic, nonnull) NSString *groupID; // @synthesize groupID=_groupID;

--- a/Sources/IMCore/include/IMChatRegistry.h
+++ b/Sources/IMCore/include/IMChatRegistry.h
@@ -87,7 +87,8 @@
 - (void)__blockUntilQueriesComplete;
 - (NSDictionary<NSString*, IMChat*>*)_chatGUIDToChatMap; // removed in monterey
 - (NSDictionary<NSString*, IMChat*>*)chatGUIDToChatMap; // introduced in monterey
-- (NSArray<IMChat*>* _Nonnull)_chatsWithMessageGUID:(NSString*)arg1;
+- (NSArray<IMChat*>* _Nonnull)_chatsWithMessageGUID:(NSString * _Nonnull)arg1 API_DEPRECATED("Use _cachedChatsWithMessageGUID on ventura and later", macos(10.0, 12.5), ios(5.0, 15.2));
+- (NSArray<IMChat*>* _Nonnull)_cachedChatsWithMessageGUID:(NSString * _Nonnull)arg1 API_AVAILABLE(macos(13.0), ios(16.0));
 - (id)_chatsWithMessage:(id)arg1;
 - (NSArray<NSString*>*)_allGUIDsForChat:(id)arg1; // removed in monterey
 - (NSArray<NSString*>*)allGUIDsForChat:(id)arg1; // introduced in monterey
@@ -117,15 +118,17 @@
 - (IMChat*)exisitingChatForGroupID:(NSString*)arg1;
 - (id)existingChatForRoom:(id)arg1 onAccount:(id)arg2;
 - (id)existingChatForIMHandles:(id)arg1;
-- (IMChat*)existingChatForIMHandle:(IMHandle*)arg1;
-- (IMChat*)existingChatWithGUID:(NSString*)arg1;
-- (id)existingChatForPersonID:(id)arg1;
-- (id)existingChatWithDisplayName:(id)arg1;
-- (IMChat*)existingChatWithChatIdentifier:(id)arg1;
-- (IMChat*)existingChatWithGroupID:(NSString*)arg1;
+- (IMChat* _Nullable)existingChatForIMHandle:(IMHandle*)arg1;
+- (IMChat* _Nullable)existingChatWithGUID:(NSString*)arg1;
+- (id _Nullable)existingChatForPersonID:(id)arg1;
+- (id _Nullable)existingChatWithDisplayName:(id)arg1;
+- (IMChat* _Nullable)existingChatWithChatIdentifier:(id)arg1;
+- (IMChat* _Nullable)existingChatWithGroupID:(NSString*)arg1;
 - (id)_lookupExistingChatWithIMHandle:(id)arg1;
-- (id)_existingChatWithIdentifier:(id)arg1 style:(unsigned char)arg2 account:(id)arg3;
-- (id)_existingChatWithIdentifier:(id)arg1 style:(unsigned char)arg2 service:(id)arg3;
+- (IMChat * _Nullable)_existingChatWithIdentifier:(id _Nonnull)arg1 style:(unsigned char)arg2 account:(NSString * _Nonnull)arg3;
+// `service` should be either @"iMessage" or @"SMS"; an IMServiceImpl.name (I think)
+- (IMChat * _Nullable)_existingChatWithIdentifier:(id _Nonnull)arg1 style:(unsigned char)arg2 service:(NSString * _Nonnull)arg3;
+- (IMChat * _Nullable)_cachedChatWithIdentifier:(id _Nonnull)arg1 API_AVAILABLE(macos(13.0), ios(16.0));
 @property(readonly, nonatomic) NSArray<IMChat*> *allExistingChats;
 @property(readonly, nonatomic) unsigned long long numberOfExistingChats;
 - (void)_setChatHasCommunicatedOveriMessage:(id)arg1;

--- a/Sources/IMFoundation/include/IMFoundation.h
+++ b/Sources/IMFoundation/include/IMFoundation.h
@@ -272,6 +272,8 @@ id IMGetDomainValueForKey(NSString * domain, NSString * key);
 BOOL IMGetDomainBoolForKey(NSString * domain, NSString * key);
 void IMSetDomainValueForKey(NSString * domain, NSString * key, id value);
 void IMSetDomainBoolForKey(NSString * domain, NSString * key, BOOL value);
+NSString * IMGetMainBundleIdentifier();
+NSBundle * IMGetMainBundle();
 
 NSString* const kFZServiceDefaultsAliasesKey;
 NSString* const kFZServiceDefaultsAliasKey;

--- a/Sources/IMSharedUtilities/include/IMItem.h
+++ b/Sources/IMSharedUtilities/include/IMItem.h
@@ -9,7 +9,7 @@
 #import "IMFoundation.h"
 #import <Foundation/Foundation.h>
 
-@class NSData, NSDate, NSDictionary, NSString, IMMessage, IMTapback;
+@class NSData, NSDate, NSDictionary, NSString, IMMessage, IMTapback, IMServiceImpl;
 
 typedef NS_ENUM(int64_t, IMItemType) {
     IMItemTypeMessage,
@@ -81,7 +81,7 @@ typedef NS_ENUM(int64_t, IMItemType) {
 @property(retain, nonatomic) NSString *accountID; // @synthesize accountID=_accountID;
 @property(retain, nonatomic) NSString *unformattedID; // @synthesize unformattedID=_unformattedID;
 @property(retain, nonatomic) NSString *account; // @synthesize account=_account;
-@property(retain, nonatomic) NSString *service; // @synthesize service=_service;
+@property(retain, nonatomic) NSString *service;
 @property(retain, nonatomic) NSString *handle; // @synthesize handle=_handle;
 @property(readonly, nonatomic) BOOL isLastMessageCandidate;
 @property(readonly, nonatomic) BOOL isFirstMessageCandidate;
@@ -93,6 +93,7 @@ typedef NS_ENUM(int64_t, IMItemType) {
 @property(retain, nonatomic, nullable) NSString *sender;
 @property(readonly, nonatomic) BOOL isFromMe;
 - (id)dictionaryRepresentation;
+- (IMServiceImpl * _Nullable)_service API_AVAILABLE(macos(13.0), ios(16.0));
 - (id)copyDictionaryRepresentation;
 - (id)initWithIMRemoteObjectSerializedDictionary:(id)arg1;
 - (void)encodeWithIMRemoteObjectSerializedDictionary:(id)arg1;


### PR DESCRIPTION
Update some methods that are used to retrieve `IMChat`s with new methods for ventura, plus some more specific types and nullability specifiers to make things clearer