### PR TITLE
Changes to improve IDS methods (plus a little extra)

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
  .withPrivateFrameworkBinding("IDS", dependencies: ["IDSFoundation"])
  .withPrivateFrameworkBinding("FTServices", dependencies: ["IDSFoundation"])
  .withPrivateFrameworkBinding("CoreSymbolication")
+ .withPrivateFrameworkBinding("CommonUtilities")
  .withPrivateFrameworkBinding("CommunicationsFilter")
  .withPrivateFrameworkBinding("TextInput")
  .withPrivateFrameworkBinding("RemoteTextInput", dependencies: ["TextInput"])

--- a/Sources/CommonUtilities/include/CUTResult.h
+++ b/Sources/CommonUtilities/include/CUTResult.h
@@ -1,0 +1,21 @@
+//
+//  CUTResult.h
+//  
+//
+//  Created by June Welker on 3/6/23.
+//
+
+#ifndef CUTResult_h
+#define CUTResult_h
+
+#import <Foundation/Foundation.h>
+
+@interface CUTResult<__covariant Success>: NSObject {
+	long long _state;
+}
+
+- (Success)value;
+- (NSError *)error;
+@end
+
+#endif /* CUTResult_h */

--- a/Sources/CommonUtilities/include/CommonUtilities.h
+++ b/Sources/CommonUtilities/include/CommonUtilities.h
@@ -1,0 +1,13 @@
+//
+//  CommonUtilities.h
+//  
+//
+//  Created by June Welker on 3/6/23.
+//
+
+#ifndef CommonUtilities_h
+#define CommonUtilities_h
+
+#import "CUTResult.h"
+
+#endif /* CommonUtilities_h */

--- a/Sources/CommonUtilities/include/module.modulemap
+++ b/Sources/CommonUtilities/include/module.modulemap
@@ -1,0 +1,3 @@
+module CommonUtilities {
+  header "CommonUtilities.h"
+}

--- a/Sources/CommonUtilities/src/CommonUtilities.m
+++ b/Sources/CommonUtilities/src/CommonUtilities.m
@@ -1,0 +1,8 @@
+//
+//  CommonUtilities.m
+//  
+//
+//  Created by June Welker on 3/6/23.
+//
+
+#import <CommonUtilities.h>

--- a/Sources/IDS/include/_IDSIDQueryController.h
+++ b/Sources/IDS/include/_IDSIDQueryController.h
@@ -8,7 +8,7 @@
 
 #import "IDSDaemonListenerProtocol.h"
 
-@class NSMapTable, NSMutableDictionary, NSObject, NSString;
+@class NSMapTable, NSMutableDictionary, NSObject, NSString, CUTResult<T>;
 
 @interface _IDSIDQueryController : NSObject
 {
@@ -41,7 +41,8 @@
 - (BOOL)_sync_currentIDStatusForDestinations:(id)arg1 service:(id)arg2 listenerID:(id)arg3 completionBlock:(id)arg4;
 - (BOOL)_sync_refreshIDStatusForDestinations:(id)arg1 service:(id)arg2 listenerID:(id)arg3 completionBlock:(id)arg4;
 - (BOOL)_refreshIDStatusForDestinations:(id)arg1 service:(id)arg2 listenerID:(id)arg3 allowRefresh:(BOOL)arg4 waitForReply:(BOOL)arg5 forceRefresh:(BOOL)arg6 queue:(id)arg7 completionBlock:(id)arg8;
-- (void)_idStatusForDestinations:(id)arg1 service:(id)arg2 listenerID:(id)arg3 allowRenew:(BOOL)arg4 waitForReply:(BOOL)arg5 forceRefresh:(BOOL)arg6 completionBlock:(id)arg7;
+- (void)_idStatusForDestinations:(id)arg1 service:(id)arg2 listenerID:(id)arg3 allowRenew:(BOOL)arg4 waitForReply:(BOOL)arg5 forceRefresh:(BOOL)arg6 completionBlock:(id)arg7 API_DEPRECATED("Use the method with more arguments instead", macos(10.0, 12.5));
+- (void)_idStatusForDestinations:(NSArray<NSString *>*)arg1 service:(NSString *)arg2 listenerID:(NSString *)arg3 allowRenew:(BOOL)arg4 respectExpiry:(BOOL)arg5 waitForReply:(BOOL)arg6 forceRefresh:(BOOL)arg7 bypassLimit:(BOOL)arg8 completionBlock:(void (^_Nonnull)(CUTResult<NSDictionary<NSString *, NSNumber *>*>*))arg9 API_AVAILABLE(macos(13.0));
 - (void)_setCurrentIDStatus:(long long)arg1 forDestination:(id)arg2 service:(id)arg3;
 - (id)_delegateMapForListenerID:(id)arg1 service:(id)arg2;
 - (void)_callDelegatesWithBlock:(id)arg1 delegateMap:(id)arg2;

--- a/Sources/IMCore/include/IMAccount.h
+++ b/Sources/IMCore/include/IMAccount.h
@@ -241,8 +241,8 @@ typedef NS_ENUM(NSInteger, IMAccountRegistrationFailureReason) {
 @property(readonly, nonatomic, nonnull) NSArray<NSString*> *aliases;
 @property(readonly, nonatomic, getter=isMakoAccount) BOOL makoAccount;
 - (id)_statuses;
-- (id)_aliasInfoForAlias:(id)arg1;
-- (BOOL)_aliasIsVisible:(id)arg1;
+- (NSDictionary<NSString *, id> * _Nullable)_aliasInfoForAlias:(NSString * _Nonnull)arg1;
+- (BOOL)_aliasIsVisible:(id _Nonnull)arg1;
 - (id)_aliases;
 @property(readonly, nonatomic) NSArray *aliasesToRegister;
 @property(readonly, nonatomic) NSArray<NSString*> *vettedAliases;

--- a/Sources/IMCore/include/IMChat.h
+++ b/Sources/IMCore/include/IMChat.h
@@ -163,8 +163,8 @@ typedef NS_ENUM(NSInteger, IMChatJoinState) {
 - (void)join;
 @property(retain, nonatomic) IMHandle *recipient;
 - (void)setRecipient:(id)arg1 locally:(BOOL)arg2;
-- (void)_setAccount:(id)arg1 locally:(BOOL)arg2;
-- (void)_setAccount:(id)arg1;
+- (void)_setAccount:(IMAccount *)arg1 locally:(BOOL)arg2;
+- (void)_setAccount:(IMAccount *)arg1;
 - (BOOL)_hasCommunicatedOnService:(id)arg1;
 - (id)_generatePersonCentricID;
 - (void)setValue:(id)arg1 forProperty:(id)arg2 ofParticipant:(id)arg3;

--- a/Sources/IMCore/include/IMDaemonListener.h
+++ b/Sources/IMCore/include/IMDaemonListener.h
@@ -6,7 +6,7 @@
 
 #import <objc/NSObject.h>
 
-@class NSArray, NSDaIMDaemonListenernary, NSMutableArray, NSMutableDictionary, NSProtocolChecker, NSString;
+@class NSArray, NSMutableArray, NSMutableDictionary, NSProtocolChecker, NSString;
 
 @interface IMDaemonListener : NSObject
 {

--- a/Sources/IMDaemonCore/include/IMDaemonCore.h
+++ b/Sources/IMDaemonCore/include/IMDaemonCore.h
@@ -27,6 +27,7 @@ typedef void (^IMAttachmentSyncFetchOperationCompletionBlock)(NSError * _Nullabl
 - (IMMessageItem *) storeMessage:(IMMessageItem *)message forceReplace:(BOOL)force modifyError:(BOOL)modifyError modifyFlags:(BOOL)modifyFlags flagMask:(uint64_t)flagMask updateMessageCache:(BOOL)updateMessageCache calculateUnreadCount:(BOOL)calculateUnreadCount;
 - (IMMessageItem *) storeMessage:(IMMessageItem *)message forceReplace:(BOOL)force modifyError:(BOOL)modifyError modifyFlags:(BOOL)modifyFlags flagMask:(uint64_t)flagMask;
 - (void)setSuppressDatabaseUpdates:(BOOL)suppress;
+- (BOOL)isSuppressDatabaseUpdates;
 @end
 
 NS_ASSUME_NONNULL_END


### PR DESCRIPTION
- Add `CommonUtilites` target to use `CUTResult`
- Fix up some types in `IMChat`
- Add method on `IMDMessageStore` in `IMDaemonCore`
- Add methods for aliases and checking status of IDS destinations